### PR TITLE
Fix incorrect hidden symbol

### DIFF
--- a/scripts/dependencies
+++ b/scripts/dependencies
@@ -8,7 +8,7 @@ sudo apt-get install libtool -y
 sudo apt-get install subversion -y
 sudo apt-get install git -y
 sudo apt-get install autoconf2.13 -y
-sudo apt-get install p7zip-full -y
+sudo apt-get install p7zip-full -y
 sudo apt-get install libglu1-mesa-dev -y
 sudo apt-get install libpulse-dev -y
 sudo apt-get install libpulse-dev -y


### PR DESCRIPTION
Seems spacings is wrong  (used nbsp symbols) and cause
```
./scripts/dependencies: line 11: sudo apt-get: command not found
```
![image](https://user-images.githubusercontent.com/668524/59025284-7dc5e200-885c-11e9-8e43-8168a8604839.png)
