### PR TITLE
Add support for document server on OpenPOWER/Linux systems

### DIFF
--- a/build.pro
+++ b/build.pro
@@ -29,7 +29,13 @@ core_windows {
 	CONFIG += core_and_multimedia
 }
 core_linux {
-	CONFIG += core_and_multimedia
+	linux-g++:contains(QMAKE_HOST.arch, ppc64le): {
+		CONFIG += no_use_htmlfileinternal
+		CONFIG += no_desktop_apps
+	}
+	else {
+		CONFIG += core_and_multimedia
+	}
 }
 core_mac {
 	CONFIG += no_use_htmlfileinternal

--- a/make.py
+++ b/make.py
@@ -11,6 +11,19 @@ import build_js
 import build_server
 import deploy
 import make_common
+import os
+import platform
+
+# set up environment
+if "ppc64" in platform.machine():
+  # PhantomJS has been ignoring requests to support non-Intel machines upstream,
+  # (issues #15432, #14421, #13708) so we have to use the distro version.  The
+  # distro version in turn fails if there is no X server available and this
+  # environment variable is not set, so set it here...
+  os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+  # Debian builds libpng without VSX support for some reason (bug #959487)
+  os.environ["CFLAGS"] = "-DPNG_POWERPC_VSX_OPT=0"
 
 # parse configuration
 config.parse()

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -44,7 +44,7 @@ def parse():
 
   if check_option("platform", "native"):
     bits = "32"
-    if platform.machine().endswith('64'):
+    if platform.machine().endswith('64') or platform.machine().endswith('64le'):
       bits = "64"
     if ("windows" == host_platform):
       options["platform"] += (" win_" + bits)

--- a/scripts/core_common/make_common.py
+++ b/scripts/core_common/make_common.py
@@ -7,6 +7,8 @@ sys.path.append('..')
 import config
 import base
 
+import platform
+
 import boost
 import cef
 import icu
@@ -15,7 +17,8 @@ import v8
 
 def make():
   boost.make()
-  cef.make()
+  if "ppc64" not in platform.machine():
+    cef.make()
   icu.make()
   openssl.make()
   v8.make()

--- a/tools/linux/automate.py
+++ b/tools/linux/automate.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('../../scripts')
 import base
 import os
+import platform
 import subprocess
 
 def get_branch_name(directory):
@@ -59,7 +60,8 @@ def install_deps():
 
   # nodejs
   if not base.is_file("./node_js_setup_10.x"):
-    base.download("https://deb.nodesource.com/setup_10.x", "./node_js_setup_10.x")
+    if "ppc64le" not in platform.machine():
+      base.download("https://deb.nodesource.com/setup_10.x", "./node_js_setup_10.x")
     base.cmd("sudo", ["bash", "./node_js_setup_10.x"])
     base.cmd("sudo", ["apt-get", "install", "-y", "nodejs"])
     base.cmd("sudo", ["npm", "install", "-g", "npm"])


### PR DESCRIPTION
Tested with Debian Buster and GCC 6
GCC 8 is known not to work due to architecture-independent problems in the old version of v8 used by ONLYOFFICE

This partially resolves #859