### PR TITLE
Actualize dockerfile for builds on newer base systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM ubuntu:14.04
 
-RUN apt-get -y update
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get -y update && \
+    apt-get -y install python3 \
+                       sudo
 
 ADD . /build_tools
 WORKDIR /build_tools


### PR DESCRIPTION
* `sudo` and `python3` already installed on `ubuntu:14.04` base image,
but need to be installed manually on newer ones
* Installing update on `ubuntu:20.04` hangup on configure of `tzdata`.
Manually specify sepcific TZ data to skip this process