### PR TITLE
Add FreeBSD compilation support

### DIFF
--- a/build.pro
+++ b/build.pro
@@ -29,7 +29,13 @@ core_windows {
 	CONFIG += core_and_multimedia
 }
 core_linux {
-	CONFIG += core_and_multimedia
+	!core_freebsd {
+		CONFIG += core_and_multimedia
+	}
+}
+core_freebsd {
+	CONFIG += no_desktop_apps
+	CONFIG += no_use_htmlfileinternal
 }
 core_mac {
 	CONFIG += no_use_htmlfileinternal

--- a/make.py
+++ b/make.py
@@ -11,6 +11,7 @@ import build_js
 import build_server
 import deploy
 import make_common
+import os
 
 # parse configuration
 config.parse()
@@ -73,6 +74,16 @@ if ("1" == config.option("update")):
   if (config.check_option("module", "develop") or config.check_option("module", "server") or config.check_option("platform", "ios")):
     base.git_update("core-fonts")
 
+  # Apply patches if available
+  patchdir = base_dir + '/patches/' + base.host_platform()
+  if os.path.exists(patchdir) :
+    for root, dirs, files in os.walk(patchdir) :
+      for filename in files :
+        tmpdir = base_dir + '/../' + filename.split('.', 1)[0]
+        print('Patching directory %s' % tmpdir)
+        base.cmd("patch", ["-d", tmpdir, "-i", patchdir + "/" + filename])
+
+
 base.configure_common_apps()
 
 # developing...
@@ -87,7 +98,8 @@ if ("1" == base.get_env("OO_ONLY_BUILD_JS")):
   exit(0)
 
 # core 3rdParty
-make_common.make()
+if base.host_platform() != 'freebsd' :
+  make_common.make()
 
 # build updmodule for desktop (only for windows version)
 if ("windows" == base.host_platform()) and (config.check_option("module", "desktop")):

--- a/scripts/build_server.py
+++ b/scripts/build_server.py
@@ -41,19 +41,24 @@ def make():
   if(base.is_exist(custom_public_key)):
       base.copy_file(custom_public_key, server_build_dir + '/Common/sources')
 
+  pkgBin = "pkg"
   pkg_target = "node10"
 
   if ("linux" == base.host_platform()):
     pkg_target += "-linux"
 
+  if ("freebsd" == base.host_platform()):
+    pkg_target += "-freebsd"
+    pkgBin = "/usr/local/bin/" + pkgBin
+
   if ("windows" == base.host_platform()):
     pkg_target += "-win"
 
-  base.cmd_in_dir(server_build_dir + "/DocService", "pkg", [".", "-t", pkg_target, "--options", "max_old_space_size=4096", "-o", "docservice"])
-  base.cmd_in_dir(server_build_dir + "/FileConverter", "pkg", [".", "-t", pkg_target, "-o", "converter"])
-  base.cmd_in_dir(server_build_dir + "/Metrics", "pkg", [".", "-t", pkg_target, "-o", "metrics"])
-  base.cmd_in_dir(server_build_dir + "/SpellChecker", "pkg", [".", "-t", pkg_target, "-o", "spellchecker"])
+  base.cmd_in_dir(server_build_dir + "/DocService", pkgBin, [".", "-t", pkg_target, "--options", "max_old_space_size=4096", "-o", "docservice"])
+  base.cmd_in_dir(server_build_dir + "/FileConverter", pkgBin, [".", "-t", pkg_target, "-o", "converter"])
+  base.cmd_in_dir(server_build_dir + "/Metrics", pkgBin, [".", "-t", pkg_target, "-o", "metrics"])
+  base.cmd_in_dir(server_build_dir + "/SpellChecker", pkgBin, [".", "-t", pkg_target, "-o", "spellchecker"])
 
   example_dir = base.get_script_dir() + "/../../document-server-integration/web/documentserver-example/nodejs"
   base.cmd_in_dir(example_dir, "npm", ["install"])
-  base.cmd_in_dir(example_dir, "pkg", [".", "-t", pkg_target, "-o", "example"])
+  base.cmd_in_dir(example_dir, pkgBin, [".", "-t", pkg_target, "-o", "example"])

--- a/scripts/deploy_server.py
+++ b/scripts/deploy_server.py
@@ -94,7 +94,7 @@ def make():
       base.copy_file(core_dir + "/Common/3dParty/icu/" + platform + "/build/icudt58.dll", converter_dir + "/icudt58.dll")
       base.copy_file(core_dir + "/Common/3dParty/icu/" + platform + "/build/icuuc58.dll", converter_dir + "/icuuc58.dll")
 
-    if (0 == platform.find("linux")):
+    if (0 == platform.find("linux") and 0 != platform.find('freebsd')):
       base.copy_file(core_dir + "/Common/3dParty/icu/" + platform + "/build/libicudata.so.58", converter_dir + "/libicudata.so.58")
       base.copy_file(core_dir + "/Common/3dParty/icu/" + platform + "/build/libicuuc.so.58", converter_dir + "/libicuuc.so.58")
 
@@ -104,14 +104,18 @@ def make():
 
     if (0 == platform.find("win")):
       base.copy_files(core_dir + "/Common/3dParty/v8/v8/out.gn/" + platform + "/release/icudt*.dat", converter_dir + "/")
+    elif (0 == platform.find("freebsd")):
+      pass
     else:
       base.copy_file(core_dir + "/Common/3dParty/v8/v8/out.gn/" + platform + "/icudtl.dat", converter_dir + "/icudtl.dat")
 
     # builder
     base.copy_exe(core_build_dir + "/bin/" + platform_postfix, converter_dir, "docbuilder")
+    # XXX warning under FreeBSD
     base.copy_dir(git_dir + "/DocumentBuilder/empty", converter_dir + "/empty")
 
     # html
+    # XXX warning under FreeBSD
     base.create_dir(converter_dir + "/HtmlFileInternal")
     base.copy_exe(core_build_dir + "/lib/" + platform_postfix, converter_dir + "/HtmlFileInternal", "HtmlFileInternal")
     base.copy_files(core_dir + "/Common/3dParty/cef/" + platform + "/build/*", converter_dir + "/HtmlFileInternal")

--- a/tools/freebsd/automate.py
+++ b/tools/freebsd/automate.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import sys
+sys.path.append('../../scripts')
+import base
+import os
+import subprocess
+
+def get_branch_name(directory):
+  cur_dir = os.getcwd()
+  os.chdir(directory)
+  # detect build_tools branch
+  #command = "git branch --show-current"
+  command = "git symbolic-ref --short -q HEAD"
+  popen = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+  current_branch = "master"
+  try:
+    stdout, stderr = popen.communicate()
+    popen.wait()
+    current_branch = stdout.strip().decode("utf-8")
+  finally:
+    popen.stdout.close()
+    popen.stderr.close()
+  os.chdir(cur_dir)
+  return current_branch
+
+def install_deps():
+  # dependencies
+  packages = ["git-lite",
+  	      "bash",
+  	      "png",
+	      "jpeg",
+	      "p7zip",
+	      "qt5-qmake",
+	      "boost-libs",
+	      "npm-node10",
+	      "openjdk8",
+	      "subversion"]
+
+  base.cmd("sudo", ["pkg", "install"] + packages)
+  base.set_env('QT_SELECT', 'qt5')
+
+  # nodejs
+  if not base.is_file("./node_js_setup_10.x"):
+    base.cmd("sudo", ["touch", "./node_js_setup_10.x"])
+    base.cmd("sudo", ["npm", "install", "-g", "npm"])
+    base.cmd("sudo", ["npm", "install", "-g", "grunt-cli"])
+    base.cmd("sudo", ["npm", "install", "-g", "pkg"])
+  return
+
+if not base.is_file("./node_js_setup_10.x"):
+  print("install dependencies...")
+  install_deps()  
+
+if not base.is_dir("./qt"):  
+    base.cmd("mkdir", ["qt",])
+    base.cmd("ln", ["-s", "/usr/local/lib/qt5", "qt/gcc_64"])
+
+branch = get_branch_name("../..")
+
+array_args = sys.argv[1:]
+array_modules = []
+
+config = {}
+for arg in array_args:
+  if (0 == arg.find("--")):
+    indexEq = arg.find("=")
+    if (-1 != indexEq):
+      config[arg[2:indexEq]] = arg[indexEq + 1:]
+  else:
+    # XXX Currently only server has been checked for compilation under FreeBSD
+    if arg != 'server': 
+    	print("module %s not supported yet under FreeBSD" % arg)
+    array_modules.append(arg)
+
+if ("branch" in config):
+  branch = config["branch"]
+
+print("---------------------------------------------")
+print("build branch: " + branch)
+print("---------------------------------------------")
+
+modules = " ".join(array_modules)
+# XXX Currently only server has been checked for compilation under FreeBSD
+if "" == modules:
+  modules = "server"
+
+print("---------------------------------------------")
+print("build modules: " + modules)
+print("---------------------------------------------")
+
+build_tools_params = ["--branch", branch, 
+                      "--module", modules, 
+                      "--update", "1",
+                      "--platform", "linux_64",
+                      "--qt-dir", os.getcwd() + "/qt"]
+
+base.cmd_in_dir("../..", "./configure.py", build_tools_params)
+base.cmd_in_dir("../..", "./make.py")
+
+
+


### PR DESCRIPTION
Update these scripts (and add specific FreeBSD automate.py file) in order to get DocumentServer compiling under FreeBSD.
Please note that :
 - I added the ability to put patch files into "patches/<platform>/" directory which will be applied on the fetched git repositories before compilation. If this directory does not exist it does nothing. This can be a good solution in order to test compilation on patched git repositories ;
 - "core_and_multimedia" has been disabled for FreeBSD since Chromium compilation needs a custom compilation process under FreeBSD ;
 - I restricted compilation to "server" only since I didn't worked on compilation of the other modules.

Last but not least, CC and CXX environment variables must be set respectively to clang and clang++ before executing automate.py since the pkg node's binary needs it. I tried to use base.set_env before calling pkg but for some reasons these environment variables are not passed to pkg.