### PR TITLE
Force usage of npm v6

### DIFF
--- a/tools/linux/automate.py
+++ b/tools/linux/automate.py
@@ -55,7 +55,7 @@ def install_deps():
     base.download("https://deb.nodesource.com/setup_10.x", "./node_js_setup_10.x")
     base.cmd("sudo", ["bash", "./node_js_setup_10.x"])
     base.cmd("sudo", ["apt-get", "install", "-y", "nodejs"])
-    base.cmd("sudo", ["npm", "install", "-g", "npm"])
+    base.cmd("sudo", ["npm", "install", "-g", "npm@6"])
     base.cmd("sudo", ["npm", "install", "-g", "grunt-cli"])
     base.cmd("sudo", ["npm", "install", "-g", "pkg"])
 


### PR DESCRIPTION
Upgrading npm to v7 cause `npm install` error in `server` repo
on Spellchecker compilation
We didn't found exact reason why this happens and
if this a bug in npm or just some major changes in npm from v6
to v7

This error can be repoduced with this simple Dockerfile
```
FROM node:10

RUN npm install -g npm
RUN npm -v
RUN git clone --depth 1 https://github.com/ONLYOFFICE/server.git
RUN cd server/SpellChecker && \
    npm install
```
In this Dockerfile - npm v7.5.4 installed and causing:
```
Step 5/5 : RUN cd server/SpellChecker &&     npm install
 ---> Running in 158d202d2c11
npm notice
npm notice New patch version of npm available! 7.5.4 -> 7.5.6
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v7.5.6>
npm notice Run `npm install -g npm@7.5.6` to update!
npm notice
npm ERR! code 1
npm ERR! path /server/SpellChecker/node_modules/nodehun
npm ERR! command failed
npm ERR! command sh -c node-gyp rebuild
npm ERR! make: Entering directory '/server/SpellChecker/node_modules/nodehun/build'
npm ERR! make: Leaving directory '/server/SpellChecker/node_modules/nodehun/build'
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@10.23.3 | linux | x64
npm ERR! gyp info find Python using Python version 3.5.3 found at "/usr/bin/python3"
npm ERR! gyp http GET https://nodejs.org/download/release/v10.23.3/node-v10.23.3-headers.tar.gz
npm ERR! gyp http 200 https://nodejs.org/download/release/v10.23.3/node-v10.23.3-headers.tar.gz
npm ERR! gyp http GET https://nodejs.org/download/release/v10.23.3/SHASUMS256.txt
npm ERR! gyp http 200 https://nodejs.org/download/release/v10.23.3/SHASUMS256.txt
npm ERR! gyp info spawn /usr/bin/python3
npm ERR! gyp info spawn args [ '/usr/local/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/server/SpellChecker/node_modules/nodehun/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/local/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/root/.cache/node-gyp/10.23.3/include/node/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/root/.cache/node-gyp/10.23.3',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/usr/local/lib/node_modules/npm/node_modules/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/root/.cache/node-gyp/10.23.3/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/server/SpellChecker/node_modules/nodehun',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.' ]
npm ERR! gyp info spawn make
npm ERR! gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm ERR! make: *** No rule to make target 'Release/obj.target/hunspell/src/hunspell/src/hunspell/affentry.o', needed by 'Release/obj.target/src/hunspell.a'.  Stop.
npm ERR! gyp ERR! build error
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (events.js:198:13)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12)
npm ERR! gyp ERR! System Linux 5.4.0-65-generic
npm ERR! gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm ERR! gyp ERR! cwd /server/SpellChecker/node_modules/nodehun
npm ERR! gyp ERR! node -v v10.23.3
npm ERR! gyp ERR! node-gyp -v v7.1.2
npm ERR! gyp ERR! not ok

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-02-23T13_33_15_384Z-debug.log
```

But if we force npm v6:
```
FROM node:10

RUN npm install -g npm@6
RUN npm -v
RUN git clone --depth 1 https://github.com/ONLYOFFICE/server.git
RUN cd server/SpellChecker && \
    npm install
```

Forcing install of npm v6.14.11 and server Spellchecker
compilation is fine