### PR TITLE
Fix key verification for nodejs installation

### DIFF
--- a/tools/linux/automate.py
+++ b/tools/linux/automate.py
@@ -53,6 +53,7 @@ def install_deps():
   # nodejs
   if not base.is_file("./node_js_setup_10.x"):
     base.download("https://deb.nodesource.com/setup_10.x", "./node_js_setup_10.x")
+    base.cmd('curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -')
     base.cmd("sudo", ["bash", "./node_js_setup_10.x"])
     base.cmd("sudo", ["apt-get", "install", "-y", "nodejs"])
     base.cmd("sudo", ["npm", "install", "-g", "npm@6"])


### PR DESCRIPTION
For some reason installing nodejs on Ubuntu 14.04
will result in error:
```
WARNING: The following packages cannot be authenticated!
  nodejs
```
See also:
https://github.com/nodesource/distributions/issues/1181