### PR TITLE
Install both python2 and python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get -y update && \
-    apt-get -y install python3 \
+    apt-get -y install python \
+                       python3 \
                        sudo
-
+RUN rm /usr/bin/python && ln -s /usr/bin/python2 /usr/bin/python
 ADD . /build_tools
 WORKDIR /build_tools
 


### PR DESCRIPTION
`build_tools` are not require python2, but it use
Google Build tools to build v8 and those tools are still require
python2

This changes allow correctly build our product on all systems starting
from Ubuntu 14.04 and until Ubuntu 20.04 including Debian 10