### PR TITLE
Update base QA build image to ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
Ubuntu 14.04 is EOLed in 2019 and now there is major problem:

qt is downloaded from
```
https://qt-mirror.dannhauer.de/
```

This host uses the Let's Encrypt certificate, but for ubuntu 14.04
new root cert is not aviable
There is several workarounds for this, but they are rather complicated
Like this one:
https://askubuntu.com/a/1366719/39452

No point of making this workaround, much simpler just update base image