### PR TITLE
Update Ubuntu requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the `master` branch.
 
 ## How to use - Linux
 
-**Note**: The solution has been tested on **Ubuntu 14.04**.
+**Note**: The solution has been tested on **Ubuntu 16.04**.
 
 ### Installing dependencies
 


### PR DESCRIPTION
Since https://github.com/ONLYOFFICE/build_tools/pull/455
We use Ubuntu 16.04 as base test, because Ubuntu 14.04 cannot
download QT from Let's Encrypt site
More details in #455