### PR TITLE
refactor: remove semicolon from python scripts

### DIFF
--- a/develop/run_build_js.py
+++ b/develop/run_build_js.py
@@ -8,7 +8,7 @@ import run_server
 import config
 import base
 
-git_dir = sys.argv[1];
+git_dir = sys.argv[1]
 
 base.print_info('argv :'+' '.join(sys.argv))
 base.cmd_in_dir(git_dir + '/build_tools/', 'python3', ['configure.py', '--develop', '1'] + sys.argv[2:])
@@ -18,7 +18,7 @@ config.parse_defaults()
 
 if base.is_exist(git_dir + "/server/FileConverter/bin/fonts.log"):
   base.print_info('remove font cache to regenerate fonts in external sdkjs volume')
-  base.delete_file(git_dir + "/server/FileConverter/bin/fonts.log");
+  base.delete_file(git_dir + "/server/FileConverter/bin/fonts.log")
 
 # external server volume
 if base.is_exist(sys.argv[1] + '/server/DocService/package.json'):
@@ -28,7 +28,7 @@ if base.is_exist(sys.argv[1] + '/server/DocService/package.json'):
   base.replaceInFileRE("/etc/supervisor/conf.d/ds-converter.conf", "command=.*", "command=node " + git_dir + "/server/FileConverter/sources/convertermaster.js")
   base.replaceInFileRE("/app/ds/setup/config/supervisor/ds/ds-converter.conf", "command=.*", "command=node " + git_dir + "/server/FileConverter/sources/convertermaster.js")
   base.print_info('run_server.run_docker_server')
-  run_server.run_docker_server();
+  run_server.run_docker_server()
 else:
   #Fix theme generation for external sdkjs volume
   if base.is_exist(git_dir + "/server/FileConverter/bin/DoctRenderer.config"):

--- a/scripts/base.py
+++ b/scripts/base.py
@@ -608,7 +608,7 @@ def update_repositories(repositories):
       git_update(repo, value[0], False)
     else:
       if is_dir(current_dir + "/.git"):
-        delete_dir_with_access_error(current_dir);
+        delete_dir_with_access_error(current_dir)
         delete_dir(current_dir)
       if not is_dir(current_dir):
         create_dir(current_dir)
@@ -1567,7 +1567,7 @@ def restorePathForBuilder(new_path):
   old_path = new_path[:-4]
   delete_file(old_path)
   copy_file(new_path, old_path)
-  delete_file(new_path);
+  delete_file(new_path)
   return
 
 def generate_check_linux_system(build_tools_dir, out_dir):

--- a/scripts/build_js.py
+++ b/scripts/build_js.py
@@ -33,7 +33,7 @@ def make():
   base.set_env('NODE_ENV', 'production')
 
   base_dir = base.get_script_dir() + "/.."
-  out_dir = base_dir + "/out/js/";
+  out_dir = base_dir + "/out/js/"
   branding = config.option("branding-name")
   if ("" == branding):
     branding = "onlyoffice"

--- a/scripts/core_common/modules/boost.py
+++ b/scripts/core_common/modules/boost.py
@@ -22,10 +22,10 @@ def move_debug_libs_windows(dir):
 
 def clean():
   if base.is_dir("boost_1_58_0"):
-    base.delete_dir_with_access_error("boost_1_58_0");
+    base.delete_dir_with_access_error("boost_1_58_0")
     base.delete_dir("boost_1_58_0")
   if base.is_dir("boost_1_72_0"):
-    base.delete_dir_with_access_error("boost_1_72_0");
+    base.delete_dir_with_access_error("boost_1_72_0")
     base.delete_dir("boost_1_72_0")
   if base.is_dir("build"):
     base.delete_dir("build")

--- a/scripts/core_common/modules/glew.py
+++ b/scripts/core_common/modules/glew.py
@@ -8,7 +8,7 @@ import os
 
 def clean():
   if base.is_dir("glew-2.1.0"):
-    base.delete_dir("glew-2.1.0");
+    base.delete_dir("glew-2.1.0")
   return
 
 def make():
@@ -16,7 +16,7 @@ def make():
     return
 
   if not config.check_option("module", "mobile"):
-    return;
+    return
 
   print("[fetch & build]: glew")
   base_dir = base.get_script_dir() + "/../../core/Common/3dParty/glew"

--- a/scripts/core_common/modules/v8.py
+++ b/scripts/core_common/modules/v8.py
@@ -10,10 +10,10 @@ import v8_89
 
 def clean():
   if base.is_dir("depot_tools"):
-    base.delete_dir_with_access_error("depot_tools");
+    base.delete_dir_with_access_error("depot_tools")
     base.delete_dir("depot_tools")
   if base.is_dir("v8"):
-    base.delete_dir_with_access_error("v8");
+    base.delete_dir_with_access_error("v8")
     base.delete_dir("v8")
   if base.is_exist("./.gclient"):
     base.delete_file("./.gclient")
@@ -269,7 +269,7 @@ def make_xp():
     "for file in projects:",
     "  replaceInFile(file, '<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>', '<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>')",
     "  replaceInFile(file, '<RuntimeLibrary>MultiThreaded</RuntimeLibrary>', '<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>')",
-    ]);
+    ])
 
   programFilesDir = base.get_env("ProgramFiles")
   if ("" != base.get_env("ProgramFiles(x86)")):

--- a/scripts/deploy_desktop.py
+++ b/scripts/deploy_desktop.py
@@ -40,7 +40,7 @@ def make():
     isWindowsXP = False if (-1 == native_platform.find("_xp")) else True
     platform = native_platform[0:-3] if isWindowsXP else native_platform
 
-    apps_postfix = "build" + base.qt_dst_postfix();
+    apps_postfix = "build" + base.qt_dst_postfix()
     if ("" != config.option("branding")):
       apps_postfix += ("/" + config.option("branding"))
     apps_postfix += "/"

--- a/scripts/sln.py
+++ b/scripts/sln.py
@@ -128,7 +128,7 @@ def get_projects(pro_json_path, platform):
       is_needed_platform_exist = False
       for pl in platform_records:
         if is_exist_in_array(params, pl):
-          is_needed_platform_exist = True;
+          is_needed_platform_exist = True
           break
 
       # if one config exists => all needed must exists
@@ -139,7 +139,7 @@ def get_projects(pro_json_path, platform):
         if is_exist_in_array(platform_records, item):
           continue
         is_needed_config_exist = True
-        break;
+        break
 
       if is_needed_platform_exist:
         if not is_exist_in_array(params, platform):


### PR DESCRIPTION
Semicolons are unnecessary when there's only one statement on a single line.