### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get -y update && \
-    apt-get -y install python \
-                       python3 \
+    apt-get -y install python3 \
                        sudo
-RUN rm /usr/bin/python && ln -s /usr/bin/python2 /usr/bin/python
+RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD . /build_tools
 WORKDIR /build_tools
 


### PR DESCRIPTION
Switch to Python 3: Required for f-string support in build scripts