### PR TITLE
Repos and branches individual overrides

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -42,6 +42,8 @@ parser.add_option("--vs-version", action="store", type="string", dest="vs-versio
 parser.add_option("--vs-path", action="store", type="string", dest="vs-path", default="", help="path to vcvarsall")
 parser.add_option("--siteUrl", action="store", type="string", dest="siteUrl", default="127.0.0.1", help="site url")
 parser.add_option("--multiprocess", action="store", type="string", dest="multiprocess", default="1", help="provides ability to specify single process for make")
+parser.add_option("--repo-overrides", action="store", type="string", dest="repo-overrides", default="", help="Comma-separated list of repo=url overrides, e.g. server=https://github.com/me/custom-server.git")
+parser.add_option("--repo-branch-overrides", action="store", type="string", dest="repo-branch-overrides", default="", help="Comma-separated list of repo=branch overrides, e.g. server=feature/new-api")
 
 (options, args) = parser.parse_args(arguments)
 configOptions = vars(options)


### PR DESCRIPTION
Fixes https://github.com/ONLYOFFICE/build_tools/issues/906 .

Thanks to this pull request you can now override individual repos urls and branches.
There's no longer need to clone/fork all of the ONLYOFFICE repos for just testing a single change in a single repo.

Usage:

```
cd tools/linux
python3 ./automate.py \
      --branch=tags/v9.0.4.52 \
      --repo-overrides=server=https://github.com/GITHUBUSER/server.git,web-apps=https://github.com/GITHUBUSER/web-apps.git \
      --repo-branch-overrides=server=tags/v9.0.4.52-change1,web-apps=tags/v9.0.4.52-change1
```

## Feedback is welcome

I am very interested on adding this feature. So, please, Ascensio, give me feedback. I am willing to change this PR as much as needed so that it fits your programming/documentation style so that this can be included upstream.

Thank you!