### PR TITLE
Add specific tag build example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,16 @@ LD_LIBRARY_PATH=./ ./DesktopEditors
 
 #### Document Server
 
-##### Building Document Server
+##### Building Document Server (Latest)
 
 ```bash
 ./automate.py server
+```
+
+##### Building Document Server (Specific tag)
+
+```bash
+./automate.py --branch=tags/v9.0.4.52 server
 ```
 
 ##### Installing and configuring Document Server dependencies


### PR DESCRIPTION
Fixes https://github.com/ONLYOFFICE/build_tools/issues/903 .

Adds to README an example on how to specifically build by tag. This was already explained in issues but never added to the README.md.