### PR TITLE
README.md: Ubuntu 20.04 is needed for builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ from the `master` branch.
 
 ## How to use - Linux
 
-**Note**: The solution has been tested on **Ubuntu 16.04**.
+**Note**: The solution has been tested on **Ubuntu 20.04**.
 
 ### Installing dependencies
 


### PR DESCRIPTION
README.md needs to be updated to reflect that Ubuntu 20.04 (not Ubuntu 16.04) is needed for builds.

Related commit:
https://github.com/ONLYOFFICE/build_tools/commit/fa589c9523535cc3995c5975c594789d663ae44d where Dockerfile enforced Ubuntu 20.04 instead of Ubuntu 16.04 .